### PR TITLE
Fix #22

### DIFF
--- a/src/planner2.jl
+++ b/src/planner2.jl
@@ -69,7 +69,8 @@ function search(pomcp::POMCPOWPlanner, tree::POMCPOWTree, info::Dict{Symbol,Any}
     # gc_enable(false)
     i = 0
     start_us = CPUtime_us()
-    for i in 1:pomcp.solver.tree_queries
+    while i < pomcp.solver.tree_queries
+        i += 1
         s = rand(pomcp.solver.rng, tree.root_belief)
         if !POMDPs.isterminal(pomcp.problem, s)
             max_depth = min(pomcp.solver.max_depth, ceil(Int, log(pomcp.solver.eps)/log(discount(pomcp.problem))))

--- a/src/updater.jl
+++ b/src/updater.jl
@@ -1,4 +1,4 @@
 function POMDPs.updater(p::POMCPOWPlanner)
     rng = MersenneTwister(rand(p.solver.rng, UInt32))
-    return SIRParticleFilter(p.problem, 10*p.solver.tree_queries, rng)
+    return BootstrapFilter(p.problem, 10*p.solver.tree_queries, rng)
 end


### PR DESCRIPTION
1. Fix tree queries update
2. Rename SIRParticleFilter to BootstrapFilter to prevent following deprecation warning:

![SIRDeprecationWarning](https://user-images.githubusercontent.com/52610169/110257044-3270c400-7f59-11eb-95fe-9a2d53642386.png)

