### PR TITLE
n == 0 should imply infinite criteria value

### DIFF
--- a/src/criteria.jl
+++ b/src/criteria.jl
@@ -12,9 +12,9 @@ function select_best(crit::MaxUCB, h_node::POWTreeObsNode, rng)
     ltn = log(tree.total_n[h])
     for node in tree.tried[h]
         n = tree.n[node]
-        if n == 0 && ltn <= 0.0
+        if isinf(tree.v[node])
             criterion_value = tree.v[node]
-        elseif n == 0 && tree.v[node] == -Inf
+        elseif n == 0
             criterion_value = Inf
         else
             criterion_value = tree.v[node] + crit.c*sqrt(ltn/n)


### PR DESCRIPTION
This commit fixes https://github.com/JuliaPOMDP/POMCPOW.jl/issues/30

If the value for this node/action is already an infinity,
then we keep that infinity value as the criterion value, since UCB cannot change it.
At best, if the value were -infinity and n==0, we get -Inf + Inf == NaN, which would not be good.

Prior to this fix, if node values are initialized to zero and rewards are positive,
sometimes the first node would be explored twice before the second node gets explored the first time.