### PR TITLE
faster timekeeping

### DIFF
--- a/src/POMCPOW.jl
+++ b/src/POMCPOW.jl
@@ -130,9 +130,10 @@ Fields:
     If this is a Policy `p`, `action(p, belief)` will be called.
     If it is an object `a`, `default_action(a, pomdp, belief, ex)` will be called, and
     if this method is not implemented, `a` will be returned directly.
-
+- `timer::Function`:
+    Timekeeping method. Search iterations ended when `timer() - start_time ≥ max_time`.
 """
-@with_kw mutable struct POMCPOWSolver{RNG<:AbstractRNG} <: AbstractPOMCPSolver
+@with_kw mutable struct POMCPOWSolver{RNG<:AbstractRNG,T} <: AbstractPOMCPSolver
     eps::Float64                = 0.01
     max_depth::Int              = typemax(Int)
     criterion                   = MaxUCB(1.0)
@@ -157,6 +158,7 @@ Fields:
     init_N::Any                 = 0
     next_action::Any            = RandomActionGenerator(rng)
     default_action::Any         = ExceptionRethrow()
+    timer::T                    = () -> 1e-9*time_ns()
 end
 
 # unweighted ParticleCollections don't get anything pushed to them

--- a/src/planner2.jl
+++ b/src/planner2.jl
@@ -65,10 +65,11 @@ end
 
 
 function search(pomcp::POMCPOWPlanner, tree::POMCPOWTree, info::Dict{Symbol,Any}=Dict{Symbol,Any}())
+    timer = pomcp.solver.timer
     all_terminal = true
     # gc_enable(false)
     i = 0
-    start_us = CPUtime_us()
+    t0 = timer()
     while i < pomcp.solver.tree_queries
         i += 1
         s = rand(pomcp.solver.rng, tree.root_belief)
@@ -77,11 +78,11 @@ function search(pomcp::POMCPOWPlanner, tree::POMCPOWTree, info::Dict{Symbol,Any}
             simulate(pomcp, POWTreeObsNode(tree, 1), s, max_depth)
             all_terminal = false
         end
-        if CPUtime_us() - start_us >= pomcp.solver.max_time*1e6
+        if timer() - t0 >= pomcp.solver.max_time
             break
         end
     end
-    info[:search_time_us] = CPUtime_us() - start_us
+    info[:search_time] = timer() - t0
     info[:tree_queries] = i
 
     if all_terminal


### PR DESCRIPTION
Fix for [slow timekeeing](https://github.com/JuliaPOMDP/POMCPOW.jl/issues/29).

Not sure why the diff for `src/POMCPOW.jl` is so large (presumably some line-ending / return carriage difference), but the only real difference for that file is the addition of `timer` in the `POMCPOWSolver` struct as well as documentation for the extra field.

Regardless, tests pass and timing is improved.