### PR TITLE
fix #9

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -55,7 +55,7 @@ function D3Trees.D3Tree(t::POMCPOWTree; title="POMCPOW Tree", kwargs...)
                       a: $(tooltip_tag(t.a_labels[ba]))
                       N: $(t.n[ba])
                       V: $(t.v[ba])
-                      $(length(t.generated[ba])) children
+                      $(length(unique(t.generated[ba]))) children
                       """
         link_width = max(1.0, 20.0*sqrt(t.n[ba]/t.total_n[1]))
         link_style[ba+lenb] = "stroke-width:$link_width"


### PR DESCRIPTION
```julia
using POMDPs
using POMCPOW
using POMDPModels
using D3Trees

sol = POMCPOWSolver(tree_queries=50_000, criterion = MaxUCB(10.0))
pomdp = TigerPOMDP()
planner = solve(sol, pomdp)
a = action(planner, initialstate(pomdp))

planner.tree |> D3Tree |> inchrome
```

Before:
![pomcpow_before](https://user-images.githubusercontent.com/52610169/158101940-e2ce4c60-4b04-4b2a-a0bc-353b344b6354.png)

After:
![pomcpow_after](https://user-images.githubusercontent.com/52610169/158101944-a21b7097-c625-4f9c-bb33-6ad4aadf9ecd.png)


